### PR TITLE
Update Sections via cli

### DIFF
--- a/src/base/EntryTypeProcessor.php
+++ b/src/base/EntryTypeProcessor.php
@@ -108,7 +108,7 @@ class EntryTypeProcessor extends Processor
             'fieldLayout' => $this->exportFieldLayout($item->getFieldLayout()),
             'requiredFields' => $this->exportRequiredFields($item->getFieldLayout()),
         ], $attributeObj);
-        
+
         if (\count($entryTypeObj['requiredFields']) <= 0) {
             unset($entryTypeObj['requiredFields']);
         }
@@ -140,5 +140,31 @@ class EntryTypeProcessor extends Processor
     public function exportByUid($uid)
     {
         // TODO: Implement exportByUid() method.
+    }
+
+    /**
+     * @param array $itemObj
+     */
+    public function update(array &$itemObj)
+    {
+        $section = Craft::$app->sections->getSectionByHandle($itemObj['sectionHandle']);
+        $sectionEntryTypes = $section->getEntryTypes();
+        if ($section->type === 'single') {
+            if($sectionEntryTypes[0]->handle === $itemObj['handle']) {
+                $parsedItem = $this->parse($itemObj);
+                // get entry type
+                // set entry type
+            }
+        } else {
+            // deal with sections that can have multiple entry types
+//            foreach ($sectionEntryTypes as $sectionEntryType) {
+//                if ($sectionEntryType->handle !== $itemObj['handle']) {
+//                    continue;
+//                }
+//                $parsedItem = $this->parse($itemObj);
+//            }
+        }
+        $save = Craft::$app->sections->saveEntryType($parsedItem);
+        return $save;
     }
 }

--- a/src/base/EntryTypeProcessor.php
+++ b/src/base/EntryTypeProcessor.php
@@ -13,7 +13,6 @@ namespace pennebaker\architect\base;
 use Craft;
 use craft\elements\Entry;
 use craft\models\EntryType;
-use pennebaker\architect\Architect;
 
 /**
  * EntryTypeProcessor
@@ -141,48 +140,5 @@ class EntryTypeProcessor extends Processor
     public function exportByUid($uid)
     {
         // TODO: Implement exportByUid() method.
-    }
-
-    /**
-     * @param array $itemObj
-     */
-    public function update(array &$itemObj)
-    {
-        $section = Craft::$app->sections->getSectionByHandle($itemObj['sectionHandle']);
-        $sectionEntryTypes = $section->getEntryTypes();
-        if ($section->type === 'single') {
-            if($sectionEntryTypes[0]->handle === $itemObj['handle']) {
-                $parsedItem = $this->parse($itemObj)[0];
-                try {
-                    Craft::$app->sections->saveEntryType($parsedItem, false);
-                } catch (\Exception $e) {
-                    $errors = [
-                        'type' => [
-                            Architect::t('Could not save entry type: '. $e)
-                        ]
-                    ];
-                    return [null, $errors];
-                }
-            }
-        } else {
-            // deal with sections that can have multiple entry types
-            foreach ($sectionEntryTypes as $sectionEntryType) {
-                if ($sectionEntryType->handle !== $itemObj['handle']) {
-                    continue;
-                }
-                $parsedItem = $this->parse($itemObj)[0];
-                try {
-                    Craft::$app->sections->saveEntryType($parsedItem, false);
-                } catch (\Exception $e) {
-                    $errors = [
-                        'type' => [
-                            Architect::t('Could not save entry type: ' . $e)
-                        ]
-                    ];
-                    return [null, $errors];
-                }
-            }
-        }
-        return null;
     }
 }

--- a/src/base/EntryTypeProcessor.php
+++ b/src/base/EntryTypeProcessor.php
@@ -13,6 +13,7 @@ namespace pennebaker\architect\base;
 use Craft;
 use craft\elements\Entry;
 use craft\models\EntryType;
+use pennebaker\architect\Architect;
 
 /**
  * EntryTypeProcessor
@@ -151,20 +152,37 @@ class EntryTypeProcessor extends Processor
         $sectionEntryTypes = $section->getEntryTypes();
         if ($section->type === 'single') {
             if($sectionEntryTypes[0]->handle === $itemObj['handle']) {
-                $parsedItem = $this->parse($itemObj);
-                // get entry type
-                // set entry type
+                $parsedItem = $this->parse($itemObj)[0];
+                try {
+                    Craft::$app->sections->saveEntryType($parsedItem, false);
+                } catch (\Exception $e) {
+                    $errors = [
+                        'type' => [
+                            Architect::t('Could not save entry type: '. $e)
+                        ]
+                    ];
+                    return [null, $errors];
+                }
             }
         } else {
             // deal with sections that can have multiple entry types
-//            foreach ($sectionEntryTypes as $sectionEntryType) {
-//                if ($sectionEntryType->handle !== $itemObj['handle']) {
-//                    continue;
-//                }
-//                $parsedItem = $this->parse($itemObj);
-//            }
+            foreach ($sectionEntryTypes as $sectionEntryType) {
+                if ($sectionEntryType->handle !== $itemObj['handle']) {
+                    continue;
+                }
+                $parsedItem = $this->parse($itemObj)[0];
+                try {
+                    Craft::$app->sections->saveEntryType($parsedItem, false);
+                } catch (\Exception $e) {
+                    $errors = [
+                        'type' => [
+                            Architect::t('Could not save entry type: ' . $e)
+                        ]
+                    ];
+                    return [null, $errors];
+                }
+            }
         }
-        $save = Craft::$app->sections->saveEntryType($parsedItem);
-        return $save;
+        return null;
     }
 }

--- a/src/base/SectionProcessor.php
+++ b/src/base/SectionProcessor.php
@@ -156,7 +156,7 @@ class SectionProcessor extends Processor
         // Check section exists
         try {
             $section = Craft::$app->sections->getSectionByHandle($itemObj['handle']);
-            var_dump($section);
+//            var_dump($section);
         } catch (\Exception $e) {
             $errors = [
                 'type' => [
@@ -173,7 +173,8 @@ class SectionProcessor extends Processor
         }
         $siteSettings = $this->_getParsedSiteSettings($itemObj)['siteSettings'];
         $section->setSiteSettings($siteSettings);
-        var_dump($section);
+//        @TOOD site settings may not be set correctly, review
+//        var_dump($section);
         try {
             Craft::$app->sections->saveSection($section, false);
         } catch (\Exception $e) {

--- a/src/base/SectionProcessor.php
+++ b/src/base/SectionProcessor.php
@@ -154,17 +154,36 @@ class SectionProcessor extends Processor
     public function update(array &$itemObj)
     {
         // Check section exists
-        $section = Craft::$app->sections->getSectionByHandle($itemObj['handle']);
-        if(!$section){
-            throw Error('Section does not exist - ' . $itemObj['name']);
+        try {
+            $section = Craft::$app->sections->getSectionByHandle($itemObj['handle']);
+            var_dump($section);
+        } catch (\Exception $e) {
+            $errors = [
+                'type' => [
+                    Architect::t('Could not retreive section: ' . $e)
+                ]
+            ];
+            return [null, $errors];
         }
         foreach($itemObj as $key => $value) {
-            $section[$key] = $value;
+            // Ignore uid, id, structureId fields
+            if ($key !== 'id' && $key !== 'uid' && $key !== 'structureId') {
+                $section[$key] = $value;
+            }
         }
         $siteSettings = $this->_getParsedSiteSettings($itemObj)['siteSettings'];
         $section->setSiteSettings($siteSettings);
-        $save = Craft::$app->sections->saveSection($section);
-        return $save;
+        var_dump($section);
+        try {
+            Craft::$app->sections->saveSection($section, false);
+        } catch (\Exception $e) {
+            $errors = [
+                'type' => [
+                    Architect::t('Could not save section: ' . $e)
+                ]
+            ];
+            return [null, $errors];
+        }
     }
 
     /**

--- a/src/base/SectionProcessor.php
+++ b/src/base/SectionProcessor.php
@@ -156,7 +156,6 @@ class SectionProcessor extends Processor
         // Check section exists
         try {
             $section = Craft::$app->sections->getSectionByHandle($itemObj['handle']);
-//            var_dump($section);
         } catch (\Exception $e) {
             $errors = [
                 'type' => [
@@ -173,8 +172,6 @@ class SectionProcessor extends Processor
         }
         $siteSettings = $this->_getParsedSiteSettings($itemObj)['siteSettings'];
         $section->setSiteSettings($siteSettings);
-//        @TOOD site settings may not be set correctly, review
-//        var_dump($section);
         try {
             Craft::$app->sections->saveSection($section, false);
         } catch (\Exception $e) {

--- a/src/base/SectionProcessor.php
+++ b/src/base/SectionProcessor.php
@@ -33,15 +33,7 @@ class SectionProcessor extends Processor
      */
     public function parse(array $item): array
     {
-        foreach ($item['siteSettings'] as $settingKey => $settings) {
-            $siteSettings = new Section_SiteSettings(array_merge($settings, [
-                'siteId' => isset($settings['siteId']) ? Craft::$app->sites->getSiteByHandle($settings['siteId'])->id : Craft::$app->sites->getPrimarySite()->id,
-            ]));
-            if (isset($siteSettings['hasUrls']) && (bool) $siteSettings['hasUrls'] === false) {
-                $siteSettings['uriFormat'] = null;
-            }
-            $item['siteSettings'][$settingKey] = $siteSettings;
-        }
+        $item = $this->_getParsedSiteSettings($item);
         $section = new Section($item);
 
         return [$section, null];
@@ -151,5 +143,46 @@ class SectionProcessor extends Processor
     public function exportByUid($uid)
     {
         // TODO: Implement exportByUid() method.
+    }
+
+    /**
+     * @param array $itemObj
+     * @return bool
+     * @throws \Throwable
+     * @throws \craft\errors\SectionNotFoundException
+     */
+    public function update(array &$itemObj)
+    {
+        // Check section exists
+        $section = Craft::$app->sections->getSectionByHandle($itemObj['handle']);
+        if(!$section){
+            throw Error('Section does not exist - ' . $itemObj['name']);
+        }
+        foreach($itemObj as $key => $value) {
+            $section[$key] = $value;
+        }
+        $siteSettings = $this->_getParsedSiteSettings($itemObj)['siteSettings'];
+        $section->setSiteSettings($siteSettings);
+        $save = Craft::$app->sections->saveSection($section);
+        return $save;
+    }
+
+    /**
+     * @param $item
+     * @return mixed
+     * @throws \craft\errors\SiteNotFoundException
+     */
+    private function _getParsedSiteSettings($item)
+    {
+        foreach ($item['siteSettings'] as $settingKey => $settings) {
+            $siteSettings = new Section_SiteSettings(array_merge($settings, [
+                'siteId' => isset($settings['siteId']) ? Craft::$app->sites->getSiteByHandle($settings['siteId'])->id : Craft::$app->sites->getPrimarySite()->id,
+            ]));
+            if (isset($siteSettings['hasUrls']) && (bool) $siteSettings['hasUrls'] === false) {
+                $siteSettings['uriFormat'] = null;
+            }
+            $item['siteSettings'][$settingKey] = $siteSettings;
+        }
+        return $item;
     }
 }

--- a/src/services/ArchitectService.php
+++ b/src/services/ArchitectService.php
@@ -127,6 +127,7 @@ class ArchitectService extends Component
          */
         $updateSupport = [
             'fields',
+            'sections',
         ];
         $addedEntryTypes = [];
         $results = [];

--- a/src/services/ArchitectService.php
+++ b/src/services/ArchitectService.php
@@ -136,7 +136,7 @@ class ArchitectService extends Component
                 $results[$parseKey] = [];
                 foreach ($importObj[$parseKey] as $itemKey => $itemObj) {
                     try {
-                        if ($update && \in_array('fields', $updateSupport, true)) {
+                        if ($update && \in_array($parseKey, $updateSupport, true)) {
                             $itemErrors = Architect::$processors->$parseKey->update($itemObj);
                             if ($itemErrors) {
                                 $results[$parseKey][] = [
@@ -146,6 +146,7 @@ class ArchitectService extends Component
                                 ];
                                 continue;
                             }
+                            continue;
                         }
                         if ($parseKey === 'fieldGroups' || $parseKey === 'siteGroups') {
                             list($item, $itemErrors) = Architect::$processors->$parseKey->parse(['name' => $itemObj]);


### PR DESCRIPTION
## What changes made
- Added update method to section processor
- Migrated the code that deals with parsing the existing section's siteSettings model to a private method which can be used by both the `save` and `update` methods

## Why

Sections cannot be updated via the cli

## Concerns

I am concerned about adding [`continue` here](https://github.com/joepagan/craft-architect/blob/feature/cli-update-entrytype/src/services/ArchitectService.php#L149) as I am not sure if there is anything necessary further down in the method that this could skip.
Previously, without this `continue`, the method could reach the bottom, and in turn running both `update` and `save` methods for a processor. This would result in console errors because of the 2nd `save` running, even though the update was successful along the lines of:
>home already exists

## Testing

`/var/www/site/update.json`:

```json
{
  "sections": [
      {
          "name": "Home12",
          "handle": "home",
          "type": "single",
          "enableVersioning": true,
          "siteSettings": [
              {
                  "hasUrls": true,
                  "uriFormat": "__home__",
                  "template": "index12.twig",
                  "enabledByDefault": true
              }
          ]
      }
  ]
}
```

Run with:

`./var/www/site/craft/craft architect/import/update /var/www/site/update.json`