### PR TITLE
Update GlobalSets via cli

### DIFF
--- a/src/base/GlobalSetProcessor.php
+++ b/src/base/GlobalSetProcessor.php
@@ -12,6 +12,7 @@ namespace pennebaker\architect\base;
 
 use Craft;
 use craft\elements\GlobalSet;
+use pennebaker\architect\Architect;
 
 /**
  * GlobalSetProcessor
@@ -120,5 +121,30 @@ class GlobalSetProcessor extends Processor
     public function exportByUid($uid)
     {
         // TODO: Implement exportByUid() method.
+    }
+
+    /**
+     * @param $item
+     * @return array|null
+     * @throws \Throwable
+     */
+    public function update($item)
+    {
+        $globalSet = Craft::$app->globals->getSetByHandle($item['handle']);
+        if ($globalSet) {
+            $globalSet['name'] = $item['name'];
+            $this->setFieldLayout($item);
+            try {
+                Craft::$app->globals->saveSet($globalSet, false);
+            } catch (craft\errors\GlobalSetNotFoundException $e) {
+                $errors = [
+                    'globalSet' => [
+                        Architect::t('Could not save GlobalSet: '. $e)
+                    ]
+                ];
+                return [null, $errors];
+            }
+        }
+        return null;
     }
 }

--- a/src/services/ArchitectService.php
+++ b/src/services/ArchitectService.php
@@ -127,6 +127,7 @@ class ArchitectService extends Component
          */
         $updateSupport = [
             'fields',
+            'globalSets'
         ];
         $addedEntryTypes = [];
         $results = [];
@@ -135,7 +136,7 @@ class ArchitectService extends Component
                 $results[$parseKey] = [];
                 foreach ($importObj[$parseKey] as $itemKey => $itemObj) {
                     try {
-                        if ($update && \in_array('fields', $updateSupport, true)) {
+                        if ($update && \in_array($parseKey, $updateSupport, true)) {
                             $itemErrors = Architect::$processors->$parseKey->update($itemObj);
                             if ($itemErrors) {
                                 $results[$parseKey][] = [
@@ -145,6 +146,7 @@ class ArchitectService extends Component
                                 ];
                                 continue;
                             }
+                            continue;
                         }
                         if ($parseKey === 'fieldGroups' || $parseKey === 'siteGroups') {
                             list($item, $itemErrors) = Architect::$processors->$parseKey->parse(['name' => $itemObj]);


### PR DESCRIPTION
## What changes made
- Adding GlobalSets to `$updateSupport` array
- Adding update method to GlobalSets processor which updates global name & field layout

## Why

GlobalSets cannot be updated via the cli

## Concerns

I am concerned about adding [`continue` here](https://github.com/joepagan/craft-architect/blob/feature/cli-update-entrytype/src/services/ArchitectService.php#L149) as I am not sure if there is anything necessary further down in the method that this could skip.
Previously, without this `continue`, the method could reach the bottom, and in turn running both `update` and `save` methods for a processor. This would result in console errors because of the 2nd `save` running, even though the update was successful along the lines of:
>home already exists

In addition, not sure sure how to best prep your $errors variable, it seems different in a couple of places. Tried to setup the following:

```php
        if ($globalSet === NULL) {
            $errors = [
                'type' => [
                    Architect::t('Could not get GlobalSet: '. $item['handle']),
                ]
            ];
            return [null, $errors];
        }
```

Though with this I get the following response:

```bash
Error:
-
PHP Notice 'yii\base\ErrorException' with message 'Undefined offset: 0'

in /var/www/craft-architect/src/console/controllers/ImportController.php:109

Stack trace:
#0 /var/www/site/craft/vendor/yiisoft/yii2/base/InlineAction.php(57): pennebaker\architect\console\controllers\ImportController->actionUpdate()
#1 /var/www/site/craft/vendor/yiisoft/yii2/base/InlineAction.php(57): ::call_user_func_array:{/var/www/site/craft/vendor/yiisoft/yii2/base/InlineAction.php:57}()
#2 /var/www/site/craft/vendor/yiisoft/yii2/base/Controller.php(157): yii\base\InlineAction->runWithParams()
#3 /var/www/site/craft/vendor/yiisoft/yii2/console/Controller.php(148): pennebaker\architect\console\controllers\ImportController->runAction()
#4 /var/www/site/craft/vendor/yiisoft/yii2/base/Module.php(528): pennebaker\architect\console\controllers\ImportController->runAction()
#5 /var/www/site/craft/vendor/yiisoft/yii2/console/Application.php(180): craft\console\Application->runAction()
#6 /var/www/site/craft/vendor/craftcms/cms/src/console/Application.php(93): craft\console\Application->runAction()
#7 /var/www/site/craft/vendor/yiisoft/yii2/console/Application.php(147): craft\console\Application->runAction()
#8 /var/www/site/craft/vendor/yiisoft/yii2/base/Application.php(386): craft\console\Application->handleRequest()
#9 /var/www/site/craft/craft(22): craft\console\Application->run()
```

Can you suggest how this could be better?

## Testing

`/var/www/site/update.json`:

```json
{
  "globalSets": [
        {
            "name": "Company1",
            "handle": "company",
            "fieldLayout": {
                "Company": [
                    "companyName",
                    "companyDescription",
                ]
            }
        }
    ]
}

```

Run with:

`./var/www/site/craft/craft architect/import/update /var/www/site/update.json`